### PR TITLE
fix(etcd-cache): use the keys to generate the prefix for clear

### DIFF
--- a/internal/gocache/store/etcd/etcd.go
+++ b/internal/gocache/store/etcd/etcd.go
@@ -258,7 +258,9 @@ func (s *EtcdStore) tagKeys(key ...string) string {
 
 // Clear resets all data in the store
 func (s *EtcdStore) Clear(ctx context.Context) error {
-	_, err := s.client.Delete(ctx, EtcdPrefix+"/", clientv3.WithPrefix())
+	// 使用keys方法构建正确的键前缀
+	prefix := s.keys()
+	_, err := s.client.Delete(ctx, prefix, clientv3.WithPrefix())
 	return err
 }
 

--- a/internal/gocache/store/etcd/etcd.go
+++ b/internal/gocache/store/etcd/etcd.go
@@ -261,6 +261,12 @@ func (s *EtcdStore) Clear(ctx context.Context) error {
 	// 使用keys方法构建正确的键前缀
 	prefix := s.keys()
 	_, err := s.client.Delete(ctx, prefix, clientv3.WithPrefix())
+	if err != nil {
+		return err
+	}
+	// 还需要清理所有的 tags
+	tagsPrefix := s.tagKeys()
+	_, err = s.client.Delete(ctx, tagsPrefix, clientv3.WithPrefix())
 	return err
 }
 


### PR DESCRIPTION
fix(etcd-cache): use the keys to generate the prefix for clear